### PR TITLE
style fixes in modloadmsg for texinfo

### DIFF
--- a/easybuild/easyconfigs/t/texinfo/texinfo-5.2-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/t/texinfo/texinfo-5.2-GCC-4.8.2.eb
@@ -15,13 +15,13 @@ osdependencies = ['texlive']
 
 preinstallopts = "make TEXMF=%(installdir)s/texmf install-tex && "
 
-# This will overwrite a users TEXMFHOME so this module is best used as a build dependency
+# This will overwrite a users $TEXMFHOME so this module is best used as a build dependency
 modextravars = {'TEXMFHOME': '%(installdir)s/texmf'}
-modloadmsg    = """\n\nThis module will set/overwrite the value for the environment variable TEXMFHOME."""
-modloadmsg    += """\nIf you use a custom texmf directory (such as ~/texmf) then you should copy files found in the"""
-modloadmsg    += """\nnew TEXMFHOME to your custom directory and reset the value of TEXMFHOME to point to that space:"""
-modloadmsg    += """\n\tcp -r $TEXMFHOME/* /path/to/your/texmf"""
-modloadmsg    += """\n\texport TEXMFHOME=/path/to/your/texmf\n\n"""
+modloadmsg    = "\n\nWARNING: This texinfo module has (re)defined the value for the environment variable \\$TEXMFHOME.\n"
+modloadmsg    += "If you use a custom texmf directory (such as ~/texmf) you should copy files found in the\n"
+modloadmsg    += "new \\$TEXMFHOME to your custom directory and reset the value of \\$TEXMFHOME to point to that space:\n"
+modloadmsg    += "\tcp -r $TEXMFHOME/* /path/to/your/texmf\n"
+modloadmsg    += "\texport TEXMFHOME=/path/to/your/texmf\n\n"
 
 sanity_check_paths = {
     'files': ['bin/info', 'bin/makeinfo', 'bin/pod2texi', 'bin/texi2pdf'],


### PR DESCRIPTION
for https://github.com/hpcugent/easybuild-easyconfigs/pull/1840/files
- no need to use triple-quoted strings (that's only needed if hard newlines are included in the string
- moving newlines at the end improves readability
- use `$TEXMFHOME` (with `$`)
